### PR TITLE
Add Shebang to example

### DIFF
--- a/example/route.rb
+++ b/example/route.rb
@@ -1,3 +1,4 @@
+#!/usr/bin/env ruby -I ../lib -I lib
 require 'em-midori'
 require 'json'
 require_relative 'controllers/user_controller'


### PR DESCRIPTION
Run `ruby example/route.rb` will raise `cannot load such file -- em-midori (LoadError)`, by adding Shebang would made running example easier.