### PR TITLE
optimise camelbak and delete redundant character

### DIFF
--- a/lib/em-midori/define_class.rb
+++ b/lib/em-midori/define_class.rb
@@ -9,7 +9,7 @@ module Kernel #:nodoc:
 
   def define_error(*args)
     args.each do |arg|
-      class_name = arg.to_s.split('_').map { |word| word[0] = word[0].upcase; word }.join
+      class_name = arg.to_s.split('_').collect(&:capitalize).join
       define_class(class_name, StandardError)
     end
   end

--- a/lib/em-midori/middleware.rb
+++ b/lib/em-midori/middleware.rb
@@ -9,7 +9,7 @@ class Midori::Middleware
   def after(_request, response)
     response
   end
-  
+
   def body_accept
     [String]
   end

--- a/lib/em-midori/promise.rb
+++ b/lib/em-midori/promise.rb
@@ -13,7 +13,7 @@ def async_internal(fiber)
   chain = ->(result) {
     return if result.class != Promise
     result.then(->(val) {
-        chain.call(fiber.resume(val))
+      chain.call(fiber.resume(val))
     })
   }
   chain.call(fiber.resume)


### PR DESCRIPTION
String#camelize  is a Rails addition to String, it doesn't work with pure Ruby.
I forgot it.
So I optimise this.