### PR TITLE
Change on reverse.each

### DIFF
--- a/lib/em-midori/api.rb
+++ b/lib/em-midori/api.rb
@@ -180,7 +180,7 @@ class Midori::API
           result = -> { clean_room.instance_exec(*matched, &route.function) }.call
           clean_room.body = result if body_accept.include?(result.class)
           response = clean_room.raw_response
-          middlewares.reverse.each { |middleware| response = middleware.after(request, response) }
+          middlewares.reverse_each { |middleware| response = middleware.after(request, response) }
           return response
         end
       end


### PR DESCRIPTION
Change on reverse_each because reverse_each loops in reverse order (no
intermediate array created).