### PR TITLE
Dsh0416/rename request param

### DIFF
--- a/lib/midori/request.rb
+++ b/lib/midori/request.rb
@@ -5,7 +5,7 @@
 # @attr [String] protocol protocol version of HTTP request
 # @attr [Symbol] method HTTP method
 # @attr [String] path request path
-# @attr [Hash | nil] query_param parameter parsed from query string
+# @attr [Hash] query_param parameter parsed from query string
 # @attr [String | nil] query_string request query string
 # @attr [Hash] header request header
 # @attr [String] body request body
@@ -14,7 +14,7 @@
 # @attr [Hash] params params in the url
 class Midori::Request
   attr_accessor :ip, :port,
-                :protocol, :method, :path, :query_param, :query_string,
+                :protocol, :method, :path, :query_params, :query_string,
                 :header, :body, :parsed, :body_parsed, :params
 
   # Init Request
@@ -25,6 +25,7 @@ class Midori::Request
     @is_eventsource = false
     @parser = Http::Parser.new
     @params = {}
+    @query_params = {}
     @body = ''
     @parser.on_headers_complete = proc do
       @protocol = @parser.http_version
@@ -35,7 +36,7 @@ class Midori::Request
       @query_string = @path.match(/\?(.*?)$/)
       unless @query_string.nil?
         @query_string = @query_string[1]
-        @query_param = CGI::parse(@query_string)
+        @query_params = CGI::parse(@query_string)
       end
       @path.gsub!(/\?(.*?)$/, '')
       @method = @method.to_sym

--- a/lib/midori/request.rb
+++ b/lib/midori/request.rb
@@ -25,7 +25,7 @@ class Midori::Request
     @is_eventsource = false
     @parser = Http::Parser.new
     @params = {}
-    @query_params = {}
+    @query_params = Hash.new(Array.new)
     @body = ''
     @parser.on_headers_complete = proc do
       @protocol = @parser.http_version

--- a/spec/midori/request_spec.rb
+++ b/spec/midori/request_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Midori::Request do
       expect(request.method).to eq(:GET)
       expect(request.path).to eq('/')
       expect(request.query_string).to eq(nil)
-      expect(request.query_param).to eq(nil)
+      expect(request.query_params).to eq({})
     end
 
     it 'parse request with query_string' do
@@ -21,7 +21,7 @@ RSpec.describe Midori::Request do
       expect(request.method).to eq(:GET)
       expect(request.path).to eq('/')
       expect(request.query_string).to eq('test=1')
-      expect(request.query_param['test']).to eq(['1'])
+      expect(request.query_params['test']).to eq(['1'])
     end
   end
 


### PR DESCRIPTION
Rename `Request#request_param` to `Request#request_params`.
Set default value to `Hash.new(Array.new)`